### PR TITLE
Fix missing weather descriptions for hail

### DIFF
--- a/app/src/main/java/com/example/theloop/utils/AppUtils.java
+++ b/app/src/main/java/com/example/theloop/utils/AppUtils.java
@@ -27,7 +27,7 @@ public final class AppUtils {
             case 61, 63, 65 -> R.string.weather_rain;
             case 71, 73, 75 -> R.string.weather_snow_fall;
             case 80, 81, 82 -> R.string.weather_rain_showers;
-            case 95 -> R.string.weather_thunderstorm;
+            case 95, 96, 99 -> R.string.weather_thunderstorm;
             default -> R.string.weather_unknown;
         };
     }

--- a/app/src/test/java/com/example/theloop/utils/AppUtilsTest.java
+++ b/app/src/test/java/com/example/theloop/utils/AppUtilsTest.java
@@ -24,6 +24,8 @@ public class AppUtilsTest {
         assertEquals(R.string.weather_rain, AppUtils.getWeatherDescription(61));
         assertEquals(R.string.weather_snow_fall, AppUtils.getWeatherDescription(75));
         assertEquals(R.string.weather_thunderstorm, AppUtils.getWeatherDescription(95));
+        assertEquals(R.string.weather_thunderstorm, AppUtils.getWeatherDescription(96));
+        assertEquals(R.string.weather_thunderstorm, AppUtils.getWeatherDescription(99));
         assertEquals(R.string.weather_unknown, AppUtils.getWeatherDescription(1000));
     }
 


### PR DESCRIPTION
Added handling for weather codes 96 and 99 (thunderstorm with hail) in `AppUtils.getWeatherDescription`. These codes were previously falling through to the default 'Unknown' case, while their corresponding icons were correctly mapped to thunderstorms. This change ensures consistency between the displayed weather description and icon.

Also added unit tests to verify the correct mapping for these codes.