### PR TITLE
Optimize weather forecast date parsing

### DIFF
--- a/app/src/main/java/com/example/theloop/MainActivity.java
+++ b/app/src/main/java/com/example/theloop/MainActivity.java
@@ -90,9 +90,6 @@ public class MainActivity extends AppCompatActivity implements DashboardAdapter.
 
     private static final String DEFAULT_SECTION_ORDER = SECTION_HEADLINES + "," + SECTION_CALENDAR + "," + SECTION_FUN_FACT + "," + SECTION_HEALTH;
 
-    private static final java.time.format.DateTimeFormatter WEATHER_DATE_INPUT_FORMAT = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.getDefault());
-    private static final java.time.format.DateTimeFormatter WEATHER_DATE_DAY_FORMAT = java.time.format.DateTimeFormatter.ofPattern("EEE d", Locale.getDefault());
-
     private static final String[] CALENDAR_PROJECTION = new String[]{
             CalendarContract.Events._ID, CalendarContract.Events.TITLE, CalendarContract.Events.DTSTART,
             CalendarContract.Events.DTEND, CalendarContract.Events.EVENT_LOCATION
@@ -152,6 +149,7 @@ public class MainActivity extends AppCompatActivity implements DashboardAdapter.
 
     private String cachedLocationName;
     private WeatherResponse latestWeather;
+    private List<String> cachedForecastDates;
     private List<CalendarEvent> latestEvents;
     private int totalEventCount = 0;
     private boolean calendarQueryError = false;
@@ -207,6 +205,11 @@ public class MainActivity extends AppCompatActivity implements DashboardAdapter.
         // FIX: Use Getters for all ViewModel properties
         viewModel.getLatestWeather().observe(this, weather -> {
             latestWeather = weather;
+            if (weather != null && weather.getDaily() != null) {
+                cachedForecastDates = AppUtils.formatForecastDates(weather.getDaily().getTime());
+            } else {
+                cachedForecastDates = null;
+            }
             if (adapter != null) adapter.notifyItemChanged(POSITION_WEATHER);
         });
 
@@ -550,10 +553,11 @@ public class MainActivity extends AppCompatActivity implements DashboardAdapter.
                     TextView high = dailyHolder.high;
                     TextView low = dailyHolder.low;
 
-                    try {
-                        java.time.LocalDate date = java.time.LocalDate.parse(daily.getTime().get(i), WEATHER_DATE_INPUT_FORMAT);
-                        dayText.setText(date.format(WEATHER_DATE_DAY_FORMAT));
-                    } catch (Exception e) { dayText.setText("-"); }
+                    if (cachedForecastDates != null && i < cachedForecastDates.size()) {
+                        dayText.setText(cachedForecastDates.get(i));
+                    } else {
+                        dayText.setText("-");
+                    }
 
                     icon.setImageResource(AppUtils.getWeatherIconResource(daily.getWeatherCode().get(i)));
                     high.setText(String.format(Locale.getDefault(), "%.0f%s", daily.getTemperatureMax().get(i), tempSymbol));

--- a/app/src/main/java/com/example/theloop/MainViewModel.kt
+++ b/app/src/main/java/com/example/theloop/MainViewModel.kt
@@ -207,7 +207,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val response = api.getRandomFact("en")
                 val fact = response.body()?.text
                 if (response.isSuccessful && fact != null) {
-                    _funFactText.postValue(fact)
+                    _funFactText.postValue(fact!!)
                 } else {
                     loadFallbackFunFact()
                 }

--- a/app/src/main/java/com/example/theloop/utils/AppUtils.java
+++ b/app/src/main/java/com/example/theloop/utils/AppUtils.java
@@ -11,8 +11,32 @@ public final class AppUtils {
 
     private static final String TAG = "AppUtils";
 
+    private static final java.time.format.DateTimeFormatter WEATHER_DATE_INPUT_FORMAT = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd", java.util.Locale.getDefault());
+    private static final java.time.format.DateTimeFormatter WEATHER_DATE_DAY_FORMAT = java.time.format.DateTimeFormatter.ofPattern("EEE d", java.util.Locale.getDefault());
+
     private AppUtils() {
         // This class is not meant to be instantiated.
+    }
+
+    /**
+     * Pre-formats forecast dates to avoid repeated parsing during RecyclerView binding.
+     *
+     * @param rawDates List of date strings in "yyyy-MM-dd" format.
+     * @return List of formatted date strings (e.g., "Mon 1"), or "-" on error.
+     */
+    public static java.util.List<String> formatForecastDates(java.util.List<String> rawDates) {
+        java.util.List<String> formatted = new java.util.ArrayList<>();
+        if (rawDates == null) return formatted;
+
+        for (String raw : rawDates) {
+            try {
+                java.time.LocalDate date = java.time.LocalDate.parse(raw, WEATHER_DATE_INPUT_FORMAT);
+                formatted.add(date.format(WEATHER_DATE_DAY_FORMAT));
+            } catch (Exception e) {
+                formatted.add("-");
+            }
+        }
+        return formatted;
     }
 
     @StringRes

--- a/app/src/test/java/com/example/theloop/utils/AppUtilsTest.java
+++ b/app/src/test/java/com/example/theloop/utils/AppUtilsTest.java
@@ -40,4 +40,15 @@ public class AppUtilsTest {
         assertEquals(R.drawable.ic_weather_thunderstorm, AppUtils.getWeatherIconResource(95));
         assertEquals(R.drawable.ic_weather_cloudy, AppUtils.getWeatherIconResource(999)); // Default case
     }
+
+    @Test
+    public void formatForecastDates_formatsDatesCorrectly() {
+        java.util.List<String> rawDates = java.util.Arrays.asList("2023-10-25", "2023-10-26", "invalid-date");
+        java.util.List<String> formatted = AppUtils.formatForecastDates(rawDates);
+
+        assertEquals(3, formatted.size());
+        assertEquals("-", formatted.get(2));
+        // We verify the size and the error case.
+        // We assume locale formatting works (it depends on the environment, so strictly checking "Mon 1" might fail if locale is different)
+    }
 }


### PR DESCRIPTION
Moved the expensive LocalDate parsing from the RecyclerView's onBindViewHolder loop to the data loading phase in MainActivity. This reduces frame drops during scrolling by pre-computing formatted date strings only when the weather data changes.

Optimizations:
- Extracted date formatting logic to `AppUtils.formatForecastDates`.
- Cached formatted dates in `MainActivity`.
- Removed repetitive parsing from `populateWeatherCard`.
- Added unit tests for date formatting logic.
- Fixed a minor null-safety lint issue in MainViewModel.