### PR TITLE
feat: increase touch target for weather settings icon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2024-10-24 - Accessibility: Touch Targets
+Learning: The application contains interactive elements (e.g., icons) with touch targets smaller than the recommended 48dp, which can make them difficult to activate for users with motor impairments or large fingers.
+Action: When identifying small interactive elements, increase their size to at least 48dp using padding or layout adjustments, ensuring the visual size remains appropriate while the hit area is accessible.

--- a/app/src/main/res/layout/card_weather.xml
+++ b/app/src/main/res/layout/card_weather.xml
@@ -16,8 +16,11 @@
 
         <ImageView
             android:id="@+id/weather_settings_icon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:padding="12dp"
+            android:layout_marginTop="-12dp"
+            android:layout_marginEnd="-12dp"
             android:src="@drawable/ic_settings"
             android:contentDescription="@string/settings"
             app:layout_constraintTop_toTopOf="parent"
@@ -54,6 +57,7 @@
             android:orientation="vertical"
             android:visibility="gone"
             tools:visibility="visible"
+            android:layout_marginTop="-12dp"
             app:layout_constraintTop_toBottomOf="@id/weather_settings_icon">
 
             <LinearLayout


### PR DESCRIPTION
- Increase the touch target size of the settings icon in the weather card to 48dp to meet accessibility guidelines.
- Use padding and negative margins to maintain the original visual size and position.
- Create `.Jules/palette.md` for UX journal entries.