### PR TITLE
Add missing dimens.xml for weather card layout

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="min_touch_target_size">48dp</dimen>
+
+    <dimen name="settings_icon_padding">12dp</dimen>
+
+    <dimen name="settings_icon_negative_margin">-12dp</dimen>
+</resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,5 +4,5 @@
 
     <dimen name="settings_icon_padding">12dp</dimen>
 
-    <dimen name="settings_icon_negative_margin">-12dp</dimen>
+    <dimen name="settings_icon_negative_margin">-@dimen/settings_icon_padding</dimen>
 </resources>


### PR DESCRIPTION
Create `app/src/main/res/values/dimens.xml` with `min_touch_target_size`, `settings_icon_padding`, and `settings_icon_negative_margin` to resolve build failures caused by missing dimension resources in `card_weather.xml`. This restores compliance with accessibility requirements for touch targets.