### PR TITLE
Fix Health Connect, status bar, calendar owner, and card styling

### DIFF
--- a/app/src/main/java/com/example/theloop/DashboardAdapter.java
+++ b/app/src/main/java/com/example/theloop/DashboardAdapter.java
@@ -206,12 +206,14 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             final TextView title;
             final TextView time;
             final TextView location;
+            final TextView owner;
 
             CalendarEventItemViewHolder(View v) {
                 parent = v;
                 title = v.findViewById(R.id.event_title);
                 time = v.findViewById(R.id.event_time);
                 location = v.findViewById(R.id.event_location);
+                owner = v.findViewById(R.id.event_owner);
             }
         }
 

--- a/app/src/main/java/com/example/theloop/MainActivity.java
+++ b/app/src/main/java/com/example/theloop/MainActivity.java
@@ -426,7 +426,12 @@ public class MainActivity extends AppCompatActivity implements DashboardAdapter.
                  try {
                      startActivity(intent);
                  } catch (Exception e) {
-                     Toast.makeText(this, getString(R.string.health_settings_error), Toast.LENGTH_LONG).show();
+                     // Try opening the Health Connect app on Play Store if not found
+                     try {
+                         startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=com.google.android.apps.healthdata")));
+                     } catch (Exception ex) {
+                        Toast.makeText(this, getString(R.string.health_settings_error), Toast.LENGTH_LONG).show();
+                     }
                  }
              });
         } else {
@@ -684,12 +689,22 @@ public class MainActivity extends AppCompatActivity implements DashboardAdapter.
                     TextView title = itemHolder.title;
                     TextView time = itemHolder.time;
                     TextView loc = itemHolder.location;
+                    TextView owner = itemHolder.owner;
+
                     title.setText(event.getTitle());
                     time.setText(AppUtils.formatEventTime(this, event.getStartTime(), event.getEndTime()));
+
                     if (!TextUtils.isEmpty(event.getLocation())) {
                         loc.setText(event.getLocation());
                         loc.setVisibility(View.VISIBLE);
                     } else loc.setVisibility(View.GONE);
+
+                    if (!TextUtils.isEmpty(event.getOwnerName())) {
+                         owner.setText(event.getOwnerName());
+                         owner.setVisibility(View.VISIBLE);
+                    } else {
+                         owner.setVisibility(View.GONE);
+                    }
 
                     itemHolder.parent.setOnClickListener(v -> {
                         Uri uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, event.getId());

--- a/app/src/main/java/com/example/theloop/MainViewModel.kt
+++ b/app/src/main/java/com/example/theloop/MainViewModel.kt
@@ -62,7 +62,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val CALENDAR_PROJECTION = arrayOf(
         CalendarContract.Events._ID, CalendarContract.Events.TITLE, CalendarContract.Events.DTSTART,
-        CalendarContract.Events.DTEND, CalendarContract.Events.EVENT_LOCATION
+        CalendarContract.Events.DTEND, CalendarContract.Events.EVENT_LOCATION, CalendarContract.Events.CALENDAR_DISPLAY_NAME
     )
 
     fun fetchLocationName(location: Location) {
@@ -252,6 +252,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     val startIdx = cursor.getColumnIndexOrThrow(CalendarContract.Events.DTSTART)
                     val endIdx = cursor.getColumnIndexOrThrow(CalendarContract.Events.DTEND)
                     val locIdx = cursor.getColumnIndexOrThrow(CalendarContract.Events.EVENT_LOCATION)
+                    val ownerIdx = cursor.getColumnIndexOrThrow(CalendarContract.Events.CALENDAR_DISPLAY_NAME)
 
                     while (cursor.moveToNext() && events.size < 3) {
                         events.add(CalendarEvent(
@@ -259,7 +260,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                             cursor.getString(titleIdx),
                             cursor.getLong(startIdx),
                             cursor.getLong(endIdx),
-                            cursor.getString(locIdx)
+                            cursor.getString(locIdx),
+                            cursor.getString(ownerIdx)
                         ))
                     }
                 } ?: run {

--- a/app/src/main/java/com/example/theloop/models/CalendarEvent.java
+++ b/app/src/main/java/com/example/theloop/models/CalendarEvent.java
@@ -6,17 +6,23 @@ public class CalendarEvent {
     private final long startTime;
     private final long endTime;
     private final String location;
+    private final String ownerName;
 
-    public CalendarEvent(long id, String title, long startTime, long endTime, String location) {
+    public CalendarEvent(long id, String title, long startTime, long endTime, String location, String ownerName) {
         this.id = id;
         this.title = title;
         this.startTime = startTime;
         this.endTime = endTime;
         this.location = location;
+        this.ownerName = ownerName;
     }
 
     public long getId() {
         return id;
+    }
+
+    public String getOwnerName() {
+        return ownerName;
     }
 
     public String getTitle() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,4 +10,5 @@
     android:paddingTop="8dp"
     android:paddingStart="8dp"
     android:paddingEnd="8dp"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity" />

--- a/app/src/main/res/layout/card_calendar.xml
+++ b/app/src/main/res/layout/card_calendar.xml
@@ -4,8 +4,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:cardElevation="4dp"
-    app:cardCornerRadius="8dp"
+    app:cardElevation="0dp"
+    app:cardBackgroundColor="@color/card_background"
+    app:cardCornerRadius="24dp"
     android:layout_marginVertical="8dp">
 
     <LinearLayout

--- a/app/src/main/res/layout/card_day_ahead.xml
+++ b/app/src/main/res/layout/card_day_ahead.xml
@@ -4,8 +4,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:cardElevation="4dp"
-    app:cardCornerRadius="8dp"
+    app:cardElevation="0dp"
+    app:cardBackgroundColor="@color/card_background"
+    app:cardCornerRadius="24dp"
     android:layout_marginVertical="8dp">
 
     <LinearLayout

--- a/app/src/main/res/layout/card_fun_fact.xml
+++ b/app/src/main/res/layout/card_fun_fact.xml
@@ -4,8 +4,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:cardElevation="4dp"
-    app:cardCornerRadius="8dp"
+    app:cardElevation="0dp"
+    app:cardBackgroundColor="@color/card_background"
+    app:cardCornerRadius="24dp"
     android:layout_marginVertical="8dp">
 
     <LinearLayout

--- a/app/src/main/res/layout/card_headlines.xml
+++ b/app/src/main/res/layout/card_headlines.xml
@@ -4,8 +4,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:cardElevation="4dp"
-    app:cardCornerRadius="8dp"
+    app:cardElevation="0dp"
+    app:cardBackgroundColor="@color/card_background"
+    app:cardCornerRadius="24dp"
     android:layout_marginVertical="8dp">
 
     <LinearLayout

--- a/app/src/main/res/layout/card_health.xml
+++ b/app/src/main/res/layout/card_health.xml
@@ -4,8 +4,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="8dp"
-    app:cardCornerRadius="16dp"
-    app:cardElevation="4dp">
+    app:cardBackgroundColor="@color/card_background"
+    app:cardCornerRadius="24dp"
+    app:cardElevation="0dp">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/card_weather.xml
+++ b/app/src/main/res/layout/card_weather.xml
@@ -5,8 +5,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    app:cardElevation="4dp"
-    app:cardCornerRadius="8dp"
+    app:cardElevation="0dp"
+    app:cardBackgroundColor="@color/card_background"
+    app:cardCornerRadius="24dp"
     android:layout_marginVertical="8dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/item_calendar_event.xml
+++ b/app/src/main/res/layout/item_calendar_event.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -8,12 +9,29 @@
     android:clickable="true"
     android:focusable="true">
 
-    <TextView
-        android:id="@+id/event_title"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?attr/textAppearanceListItem"
-        android:text="Team Meeting"/>
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/event_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textAppearance="?attr/textAppearanceListItem"
+            tools:text="Team Meeting"/>
+
+        <TextView
+            android:id="@+id/event_owner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceCaption"
+            tools:text="Work"
+            android:background="?attr/colorSurfaceVariant"
+            android:paddingHorizontal="4dp"
+            android:paddingVertical="2dp"/>
+    </LinearLayout>
 
     <TextView
         android:id="@+id/event_time"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="card_background">#263238</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,4 +58,6 @@
     <string name="health_settings_error">Could not open Health Connect settings. Please open the Health Connect app manually.</string>
     <string name="fun_fact_fallback">Did you know? Code is poetry.</string>
     <string name="widget_default_summary">Open The Loop to see your day ahead.</string>
+    <string name="weather_high_prefix">H:</string>
+    <string name="weather_low_prefix"> L:</string>
 </resources>


### PR DESCRIPTION
- Fix: Handle missing Health Connect app gracefully by redirecting to Play Store.
- Fix: Add `fitsSystemWindows="true"` to RecyclerView to prevent status bar overlap.
- Feature: Display calendar owner name in event list.
- Design: Update cards to use deep dark slate background (`#263238`) and 24dp corner radius.