### PR TITLE
Add Onboarding, Settings, Padding and UK News with fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,17 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <activity
+            android:name=".SettingsActivity"
+            android:exported="false"
+            android:label="@string/settings"
+            android:parentActivityName=".MainActivity" />
+
+        <activity
+            android:name=".OnboardingActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar"/>
+
         <activity android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/example/theloop/DashboardAdapter.java
+++ b/app/src/main/java/com/example/theloop/DashboardAdapter.java
@@ -22,15 +22,19 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     static final int TYPE_CALENDAR = 3;
     static final int TYPE_FUN_FACT = 4;
     static final int TYPE_HEALTH = 5;
+    static final int TYPE_UK_NEWS = 6;
+    static final int TYPE_FOOTER = 7;
 
     // Callbacks for data binding
     public interface Binder {
         void bindHeader(HeaderViewHolder holder);
         void bindWeather(WeatherViewHolder holder);
         void bindHeadlines(HeadlinesViewHolder holder);
+        void bindUkNews(HeadlinesViewHolder holder);
         void bindCalendar(CalendarViewHolder holder);
         void bindFunFact(FunFactViewHolder holder);
         void bindHealth(HealthViewHolder holder);
+        void bindFooter(FooterViewHolder holder);
     }
 
     private final Binder binder;
@@ -46,10 +50,13 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         if (position == 0) return TYPE_HEADER;
         if (position == 1) return TYPE_WEATHER;
 
+        if (position == getItemCount() - 1) return TYPE_FOOTER;
+
         // Remaining positions map to sectionOrder
         String section = sectionOrder[position - 2];
         return switch (section) {
             case MainActivity.SECTION_HEADLINES -> TYPE_HEADLINES;
+            case MainActivity.SECTION_UK_NEWS -> TYPE_UK_NEWS;
             case MainActivity.SECTION_CALENDAR -> TYPE_CALENDAR;
             case MainActivity.SECTION_FUN_FACT -> TYPE_FUN_FACT;
             case MainActivity.SECTION_HEALTH -> TYPE_HEALTH;
@@ -59,7 +66,7 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
     @Override
     public int getItemCount() {
-        return 2 + sectionOrder.length; // Header + Weather + Sections
+        return 2 + sectionOrder.length + 1; // Header + Weather + Sections + Footer
     }
 
     @NonNull
@@ -70,9 +77,11 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             case TYPE_HEADER -> new HeaderViewHolder(inflater.inflate(R.layout.card_day_ahead, parent, false));
             case TYPE_WEATHER -> new WeatherViewHolder(inflater.inflate(R.layout.card_weather, parent, false));
             case TYPE_HEADLINES -> new HeadlinesViewHolder(inflater.inflate(R.layout.card_headlines, parent, false));
+            case TYPE_UK_NEWS -> new HeadlinesViewHolder(inflater.inflate(R.layout.card_headlines, parent, false));
             case TYPE_CALENDAR -> new CalendarViewHolder(inflater.inflate(R.layout.card_calendar, parent, false));
             case TYPE_FUN_FACT -> new FunFactViewHolder(inflater.inflate(R.layout.card_fun_fact, parent, false));
             case TYPE_HEALTH -> new HealthViewHolder(inflater.inflate(R.layout.card_health, parent, false));
+            case TYPE_FOOTER -> new FooterViewHolder(inflater.inflate(R.layout.item_settings_footer, parent, false));
             default -> throw new IllegalArgumentException("Invalid view type");
         };
     }
@@ -84,13 +93,19 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         } else if (holder instanceof WeatherViewHolder weatherHolder) {
             binder.bindWeather(weatherHolder);
         } else if (holder instanceof HeadlinesViewHolder headlinesHolder) {
-            binder.bindHeadlines(headlinesHolder);
+            if (getItemViewType(position) == TYPE_UK_NEWS) {
+                binder.bindUkNews(headlinesHolder);
+            } else {
+                binder.bindHeadlines(headlinesHolder);
+            }
         } else if (holder instanceof CalendarViewHolder calendarHolder) {
             binder.bindCalendar(calendarHolder);
         } else if (holder instanceof FunFactViewHolder funFactHolder) {
             binder.bindFunFact(funFactHolder);
         } else if (holder instanceof HealthViewHolder healthHolder) {
             binder.bindHealth(healthHolder);
+        } else if (holder instanceof FooterViewHolder footerHolder) {
+            binder.bindFooter(footerHolder);
         } else {
             throw new IllegalStateException("Unhandled ViewHolder type: " + holder.getClass().getName());
         }
@@ -164,6 +179,7 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     static class HeadlinesViewHolder extends RecyclerView.ViewHolder {
         final ProgressBar progressBar;
         final TextView errorText;
+        final TextView cardTitle;
         final LinearLayout container;
         final ChipGroup chipGroup;
         final HeadlineItemViewHolder[] headlineViews;
@@ -184,6 +200,7 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             super(v);
             progressBar = v.findViewById(R.id.headlines_progress_bar);
             errorText = v.findViewById(R.id.headlines_error_text);
+            cardTitle = v.findViewById(R.id.headlines_card_title);
             container = v.findViewById(R.id.headlines_container);
             chipGroup = v.findViewById(R.id.headlines_category_chips);
             headlineViews = new HeadlineItemViewHolder[] {
@@ -252,6 +269,15 @@ public class DashboardAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             permissionButton = v.findViewById(R.id.health_permission_button);
             errorText = v.findViewById(R.id.health_error_text);
             contentLayout = v.findViewById(R.id.health_content_layout);
+        }
+    }
+
+    static class FooterViewHolder extends RecyclerView.ViewHolder {
+        final TextView settingsLink;
+
+        FooterViewHolder(View v) {
+            super(v);
+            settingsLink = v.findViewById(R.id.settings_link);
         }
     }
 }

--- a/app/src/main/java/com/example/theloop/MainViewModel.kt
+++ b/app/src/main/java/com/example/theloop/MainViewModel.kt
@@ -57,6 +57,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _locationName = MutableLiveData<String>()
     val locationName: LiveData<String> = _locationName
 
+    private val _weatherError = MutableLiveData(false)
+    val weatherError: LiveData<Boolean> = _weatherError
+
+    private val _newsError = MutableLiveData(false)
+    val newsError: LiveData<Boolean> = _newsError
+
     private val _summary = androidx.lifecycle.MediatorLiveData<String>()
     val summary: LiveData<String> = _summary
 
@@ -142,6 +148,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val apiService = RetrofitClient.getClient().create(WeatherApiService::class.java)
                 val response = apiService.getWeather(latitude, longitude, "temperature_2m,weather_code", "weather_code,temperature_2m_max,temperature_2m_min", unit, "auto")
                 if (response.isSuccessful && response.body() != null) {
+                    _weatherError.postValue(false)
                     _latestWeather.postValue(response.body())
                     saveToCache(AppConstants.WEATHER_CACHE_KEY, response.body())
                 } else {
@@ -162,9 +169,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             try {
                 val weather = gson.fromJson(cachedJson, WeatherResponse::class.java)
                 _latestWeather.postValue(weather)
+                _weatherError.postValue(false)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load weather from cache", e)
+                _weatherError.postValue(true)
             }
+        } else {
+            _weatherError.postValue(true)
         }
     }
 
@@ -174,6 +185,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val apiService = NewsRetrofitClient.getClient().create(NewsApiService::class.java)
                 val response = apiService.getNewsFeed()
                 if (response.isSuccessful && response.body() != null) {
+                    _newsError.postValue(false)
                     _cachedNewsResponse.postValue(response.body())
                     saveToCache(AppConstants.NEWS_CACHE_KEY, response.body())
                 } else {
@@ -194,9 +206,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             try {
                 val news = gson.fromJson(cachedJson, NewsResponse::class.java)
                 _cachedNewsResponse.postValue(news)
+                _newsError.postValue(false)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to load news from cache", e)
+                _newsError.postValue(true)
             }
+        } else {
+            _newsError.postValue(true)
         }
     }
 

--- a/app/src/main/java/com/example/theloop/OnboardingActivity.kt
+++ b/app/src/main/java/com/example/theloop/OnboardingActivity.kt
@@ -1,0 +1,192 @@
+package com.example.theloop
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Bundle
+import android.text.TextUtils
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.StepsRecord
+import com.example.theloop.utils.AppConstants
+import com.google.android.material.textfield.TextInputEditText
+import kotlin.reflect.KClass
+
+class OnboardingActivity : AppCompatActivity() {
+
+    private lateinit var stepViews: Array<View>
+    private lateinit var dots: Array<ImageView>
+    private lateinit var btnNext: Button
+    private lateinit var btnSkip: Button
+    private lateinit var nameInput: TextInputEditText
+    private var currentStep = 0
+
+    private val requestLocationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            Toast.makeText(this, "Location permission granted", Toast.LENGTH_SHORT).show()
+            // Could auto-advance, but let user click Next
+            findViewById<Button>(R.id.btn_grant_location).text = "Permission Granted"
+            findViewById<Button>(R.id.btn_grant_location).isEnabled = false
+        } else {
+            Toast.makeText(this, "Permission denied", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private val requestCalendarPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            Toast.makeText(this, "Calendar permission granted", Toast.LENGTH_SHORT).show()
+            findViewById<Button>(R.id.btn_grant_calendar).text = "Permission Granted"
+            findViewById<Button>(R.id.btn_grant_calendar).isEnabled = false
+        } else {
+            Toast.makeText(this, "Permission denied", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private val healthPermissionLauncher = registerForActivityResult(
+        androidx.health.connect.client.PermissionController.createRequestPermissionResultContract()
+    ) { granted ->
+        if (granted.contains(HealthPermission.getReadPermission(StepsRecord::class))) {
+             Toast.makeText(this, "Health permission granted", Toast.LENGTH_SHORT).show()
+             findViewById<Button>(R.id.btn_grant_health).text = "Permission Granted"
+             findViewById<Button>(R.id.btn_grant_health).isEnabled = false
+        } else {
+             Toast.makeText(this, "Permission denied", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_onboarding)
+
+        stepViews = arrayOf(
+            findViewById(R.id.step_welcome),
+            findViewById(R.id.step_location),
+            findViewById(R.id.step_calendar),
+            findViewById(R.id.step_health),
+            findViewById(R.id.step_finish)
+        )
+
+        dots = arrayOf(
+            findViewById(R.id.dot_0),
+            findViewById(R.id.dot_1),
+            findViewById(R.id.dot_2),
+            findViewById(R.id.dot_3),
+            findViewById(R.id.dot_4)
+        )
+
+        btnNext = findViewById(R.id.btn_next)
+        btnSkip = findViewById(R.id.btn_skip)
+        nameInput = findViewById(R.id.name_input)
+
+        btnNext.setOnClickListener {
+            if (currentStep == 0) {
+                saveName()
+            }
+            if (currentStep < stepViews.size - 1) {
+                currentStep++
+                updateUI()
+            } else {
+                finishOnboarding()
+            }
+        }
+
+        btnSkip.setOnClickListener {
+            if (currentStep < stepViews.size - 1) {
+                currentStep++
+                updateUI()
+            } else {
+                finishOnboarding()
+            }
+        }
+
+        setupPermissionButtons()
+        updateUI()
+    }
+
+    private fun setupPermissionButtons() {
+        findViewById<Button>(R.id.btn_grant_location).setOnClickListener {
+            requestLocationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+
+        findViewById<Button>(R.id.btn_grant_calendar).setOnClickListener {
+            requestCalendarPermissionLauncher.launch(Manifest.permission.READ_CALENDAR)
+        }
+
+        findViewById<Button>(R.id.btn_grant_health).setOnClickListener {
+            if (HealthConnectClient.getSdkStatus(this) == HealthConnectClient.SDK_AVAILABLE) {
+                val permissions = setOf(
+                    HealthPermission.getReadPermission(StepsRecord::class)
+                )
+                healthPermissionLauncher.launch(permissions)
+            } else {
+                Toast.makeText(this, "Health Connect not available", Toast.LENGTH_SHORT).show()
+                 try {
+                     startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=com.google.android.apps.healthdata")))
+                 } catch (e: Exception) {
+                     android.util.Log.e("OnboardingActivity", "Failed to open Play Store for Health Connect", e)
+                 }
+            }
+        }
+    }
+
+    private fun saveName() {
+        val name = nameInput.text.toString()
+        if (!TextUtils.isEmpty(name)) {
+            getSharedPreferences(AppConstants.PREFS_NAME, Context.MODE_PRIVATE)
+                .edit()
+                .putString(AppConstants.KEY_USER_NAME, name)
+                .apply()
+        }
+    }
+
+    private fun updateUI() {
+        // Update Step Views
+        for (i in stepViews.indices) {
+            stepViews[i].visibility = if (i == currentStep) View.VISIBLE else View.GONE
+        }
+
+        // Update Dots
+        for (i in dots.indices) {
+            dots[i].setImageResource(if (i == currentStep) R.drawable.dot_active else R.drawable.dot_inactive)
+        }
+
+        // Update Buttons
+        if (currentStep == stepViews.size - 1) {
+            btnNext.text = "Go to Dashboard"
+            btnSkip.visibility = View.GONE
+        } else {
+            btnNext.text = "Next"
+            btnSkip.visibility = View.VISIBLE
+        }
+
+        if (currentStep == 0) {
+            // On the first step, allow skipping name input by making the skip button visible.
+            btnSkip.visibility = View.VISIBLE
+        }
+    }
+
+    private fun finishOnboarding() {
+        getSharedPreferences(AppConstants.PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(AppConstants.KEY_ONBOARDING_COMPLETED, true)
+            .apply()
+
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+}

--- a/app/src/main/java/com/example/theloop/SettingsActivity.kt
+++ b/app/src/main/java/com/example/theloop/SettingsActivity.kt
@@ -1,0 +1,73 @@
+package com.example.theloop
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.view.MenuItem
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import com.example.theloop.utils.AppConstants
+
+class SettingsActivity : AppCompatActivity() {
+
+    private lateinit var radioGroup: RadioGroup
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_settings)
+
+        val toolbar = findViewById<Toolbar>(R.id.settings_toolbar)
+        setSupportActionBar(toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = getString(R.string.settings)
+
+        radioGroup = findViewById(R.id.temp_unit_radio_group)
+        val versionText = findViewById<TextView>(R.id.version_text)
+
+        setupTemperatureUnits()
+
+        try {
+            val pInfo = packageManager.getPackageInfo(packageName, 0)
+            versionText.text = "Version " + pInfo.versionName
+        } catch (e: Exception) {
+            versionText.text = "Version Unknown"
+        }
+    }
+
+    private fun setupTemperatureUnits() {
+        val prefs = getSharedPreferences(AppConstants.PREFS_NAME, Context.MODE_PRIVATE)
+        val currentUnit = prefs.getString(AppConstants.KEY_TEMP_UNIT, AppConstants.DEFAULT_TEMP_UNIT)
+
+        val unitsDisplay = resources.getStringArray(R.array.temp_units_display)
+        val unitsValues = resources.getStringArray(R.array.temp_units_values)
+
+        for (i in unitsDisplay.indices) {
+            val radioButton = RadioButton(this)
+            radioButton.text = unitsDisplay[i]
+            radioButton.tag = unitsValues[i]
+            radioButton.id = i // Use index as ID
+            radioGroup.addView(radioButton)
+
+            if (unitsValues[i] == currentUnit) {
+                radioButton.isChecked = true
+            }
+        }
+
+        radioGroup.setOnCheckedChangeListener { group, checkedId ->
+            val radioButton = group.findViewById<RadioButton>(checkedId)
+            val selectedValue = radioButton.tag as String
+            prefs.edit().putString(AppConstants.KEY_TEMP_UNIT, selectedValue).apply()
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/app/src/main/java/com/example/theloop/network/NewsRetrofitClient.java
+++ b/app/src/main/java/com/example/theloop/network/NewsRetrofitClient.java
@@ -8,7 +8,7 @@ public class NewsRetrofitClient {
     private static Retrofit retrofit = null;
     private static final String BASE_URL = "https://ok.surf/api/v1/";
 
-    public static Retrofit getClient() {
+    public static synchronized Retrofit getClient() {
         if (retrofit == null) {
             retrofit = new Retrofit.Builder()
                     .baseUrl(BASE_URL)

--- a/app/src/main/java/com/example/theloop/network/RetrofitClient.java
+++ b/app/src/main/java/com/example/theloop/network/RetrofitClient.java
@@ -8,7 +8,7 @@ public class RetrofitClient {
     private static Retrofit retrofit = null;
     private static final String BASE_URL = "https://api.open-meteo.com/";
 
-    public static Retrofit getClient() {
+    public static synchronized Retrofit getClient() {
         if (retrofit == null) {
             retrofit = new Retrofit.Builder()
                     .baseUrl(BASE_URL)

--- a/app/src/main/java/com/example/theloop/utils/AppConstants.java
+++ b/app/src/main/java/com/example/theloop/utils/AppConstants.java
@@ -14,6 +14,7 @@ public final class AppConstants {
     public static final String KEY_SECTION_ORDER = "section_order";
     public static final String KEY_SUMMARY_CACHE = "summary_cache";
     public static final String KEY_FIRST_RUN = "is_first_run";
+    public static final String KEY_ONBOARDING_COMPLETED = "onboarding_completed";
     public static final String KEY_USER_NAME = "user_name";
 
     public static final String DEFAULT_TEMP_UNIT = "celsius";

--- a/app/src/main/java/com/example/theloop/utils/AppUtils.java
+++ b/app/src/main/java/com/example/theloop/utils/AppUtils.java
@@ -20,7 +20,7 @@ public final class AppUtils {
 
     private static final String TAG = "AppUtils";
 
-    private static final DateTimeFormatter WEATHER_DATE_INPUT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.getDefault());
+    private static final DateTimeFormatter WEATHER_DATE_INPUT_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.US);
     private static final DateTimeFormatter WEATHER_DATE_DAY_FORMAT = DateTimeFormatter.ofPattern("EEE d", Locale.getDefault());
 
     private AppUtils() {

--- a/app/src/main/res/drawable/dot_active.xml
+++ b/app/src/main/res/drawable/dot_active.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="?attr/colorPrimary" />
+    <size android:width="8dp" android:height="8dp" />
+</shape>

--- a/app/src/main/res/drawable/dot_inactive.xml
+++ b/app/src/main/res/drawable/dot_inactive.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#808080" />
+    <size android:width="8dp" android:height="8dp" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,7 +8,7 @@
     android:clipToPadding="false"
     android:paddingBottom="16dp"
     android:paddingTop="8dp"
-    android:paddingStart="8dp"
-    android:paddingEnd="8dp"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
     android:fitsSystemWindows="true"
     tools:context=".MainActivity" />

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <!-- Step 1: Welcome & Name -->
+    <LinearLayout
+        android:id="@+id/step_welcome"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="visible"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_container">
+
+        <ImageView
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:src="@mipmap/ic_launcher"
+            android:layout_marginBottom="32dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Welcome to The Loop"
+            android:textAppearance="?attr/textAppearanceHeadline4"
+            android:gravity="center"
+            android:layout_marginBottom="16dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Your daily dashboard for weather, news, calendar, and more."
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:gravity="center"
+            android:layout_marginBottom="32dp"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="What should we call you?">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/name_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPersonName"
+                android:singleLine="true"/>
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+
+    <!-- Step 2: Location -->
+    <LinearLayout
+        android:id="@+id/step_location"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_container">
+
+        <ImageView
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:src="@mipmap/ic_launcher"
+            android:layout_marginBottom="24dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Location Access"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:layout_marginBottom="16dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="To provide accurate weather forecasts for your area, we need access to your location."
+            android:gravity="center"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:layout_marginBottom="32dp"/>
+
+        <Button
+            android:id="@+id/btn_grant_location"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Grant Location Permission"/>
+    </LinearLayout>
+
+    <!-- Step 3: Calendar -->
+    <LinearLayout
+        android:id="@+id/step_calendar"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_container">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Calendar Access"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:layout_marginBottom="16dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Stay on top of your schedule. The Loop shows your upcoming events."
+            android:gravity="center"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:layout_marginBottom="32dp"/>
+
+        <Button
+            android:id="@+id/btn_grant_calendar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Grant Calendar Permission"/>
+    </LinearLayout>
+
+    <!-- Step 4: Health -->
+    <LinearLayout
+        android:id="@+id/step_health"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_container">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Health Connect"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            android:layout_marginBottom="16dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Track your steps directly on your dashboard using Health Connect."
+            android:gravity="center"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:layout_marginBottom="32dp"/>
+
+        <Button
+            android:id="@+id/btn_grant_health"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Connect Health Data"/>
+    </LinearLayout>
+
+    <!-- Step 5: Finish -->
+    <LinearLayout
+        android:id="@+id/step_finish"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_container">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="You're All Set!"
+            android:textAppearance="?attr/textAppearanceHeadline4"
+            android:layout_marginBottom="16dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="The Loop is ready to help you start your day."
+            android:gravity="center"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:layout_marginBottom="32dp"/>
+    </LinearLayout>
+
+
+    <!-- Bottom Navigation -->
+    <LinearLayout
+        android:id="@+id/bottom_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <!-- Dots -->
+        <LinearLayout
+            android:id="@+id/dots_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:layout_marginBottom="16dp">
+
+            <ImageView
+                android:id="@+id/dot_0"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:src="@drawable/dot_active"
+                android:layout_margin="4dp"/>
+             <ImageView
+                android:id="@+id/dot_1"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:src="@drawable/dot_inactive"
+                android:layout_margin="4dp"/>
+             <ImageView
+                android:id="@+id/dot_2"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:src="@drawable/dot_inactive"
+                android:layout_margin="4dp"/>
+             <ImageView
+                android:id="@+id/dot_3"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:src="@drawable/dot_inactive"
+                android:layout_margin="4dp"/>
+             <ImageView
+                android:id="@+id/dot_4"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:src="@drawable/dot_inactive"
+                android:layout_margin="4dp"/>
+        </LinearLayout>
+
+        <Button
+            android:id="@+id/btn_next"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Next"
+            style="@style/Widget.MaterialComponents.Button"/>
+
+        <Button
+            android:id="@+id/btn_skip"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Skip"
+            style="@style/Widget.MaterialComponents.Button.TextButton"/>
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="?android:attr/colorBackground">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/settings_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <!-- Temperature Unit -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Temperature Unit"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                android:layout_marginBottom="8dp" />
+
+            <RadioGroup
+                android:id="@+id/temp_unit_radio_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="24dp">
+                <!-- RadioButtons will be added programmatically or we can use dialog on click -->
+            </RadioGroup>
+
+            <!-- About -->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="About"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:id="@+id/version_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Version 1.0"
+                android:textAppearance="?attr/textAppearanceBody2" />
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/app/src/main/res/layout/card_headlines.xml
+++ b/app/src/main/res/layout/card_headlines.xml
@@ -16,6 +16,7 @@
         android:padding="16dp">
 
         <TextView
+            android:id="@+id/headlines_card_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Top Headlines"

--- a/app/src/main/res/layout/item_settings_footer.xml
+++ b/app/src/main/res/layout/item_settings_footer.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/settings_link"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/settings"
+        android:textColor="?attr/colorPrimary"
+        android:textAppearance="?attr/textAppearanceButton"
+        android:background="?attr/selectableItemBackground"
+        android:padding="8dp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -8,6 +8,19 @@
         <item>celsius</item>
         <item>fahrenheit</item>
     </string-array>
+    <string-array name="uk_news_sources">
+        <item>BBC</item>
+        <item>The Guardian</item>
+        <item>Sky News</item>
+        <item>The Independent</item>
+        <item>Telegraph</item>
+        <item>Daily Mail</item>
+        <item>Mirror</item>
+        <item>Financial Times</item>
+        <item>The Sun</item>
+        <item>Metro</item>
+        <item>Standard</item>
+    </string-array>
     <string-array name="fun_facts">
         <item>Honey never spoils.</item>
         <item>Bananas are berries, but strawberries aren\'t.</item>


### PR DESCRIPTION
- Increased paddingStart/End to 24dp in activity_main.xml.
- Created SettingsActivity and linked it via a new Footer item in DashboardAdapter.
- Created OnboardingActivity for initial setup and permission requests (Location, Calendar, Health).
- Updated MainActivity to check for onboarding completion.
- Added SECTION_UK_NEWS to DashboardAdapter, placed at the front.
- Implemented client-side filtering of World news for UK sources (loaded from arrays.xml) to populate the UK News section.
- Moved temperature unit selection to SettingsActivity.
- Fixed NullPointerException on article clicks.
- Added thread safety to Retrofit clients.
- Implemented error handling for infinite loading states in Weather and News cards.
- Fixed date parsing to use Locale.US.
- Refactored constants and prevented duplicate news fetches.