### PR TITLE
Enable R8 minification and resource shrinking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,25 @@
+# Add project specific ProGuard rules here.
+
+# Gson
+# Gson uses generic type information stored in a class file when working with fields. ProGuard
+# removes such information by default, so configure it to keep all of it.
+-keepattributes Signature
+
+# For using GSON @Expose annotation
+-keepattributes *Annotation*
+
+# Gson specific classes
+-keep class sun.misc.Unsafe { *; }
+-keep class com.google.gson.stream.** { *; }
+
+# Application classes that will be serialized/deserialized over Gson
+-keep class com.example.theloop.models.** { *; }
+
+# WorkManager
+-keep class androidx.work.Worker { *; }
+-keep class androidx.work.ListenableWorker { *; }
+
+# ViewModels
+-keepclassmembers class * extends androidx.lifecycle.ViewModel {
+    <init>(...);
+}


### PR DESCRIPTION
Enabled `minifyEnabled` and `shrinkResources` for the release build type to reduce APK size. Added `app/proguard-rules.pro` with necessary keep rules for Gson, Retrofit, WorkManager, and ViewModels to prevent runtime issues caused by obfuscation.