### PR TITLE
Refactor: Move name validation to OnboardingViewModel

### DIFF
--- a/app/src/main/java/com/example/theloop/OnboardingViewModel.kt
+++ b/app/src/main/java/com/example/theloop/OnboardingViewModel.kt
@@ -23,8 +23,10 @@ class OnboardingViewModel @Inject constructor(
     }
 
     fun saveName() {
-        viewModelScope.launch {
-            userPreferencesRepository.saveUserName(name.value)
+        if (name.value.isNotBlank()) {
+            viewModelScope.launch {
+                userPreferencesRepository.saveUserName(name.value)
+            }
         }
     }
 

--- a/app/src/main/java/com/example/theloop/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/java/com/example/theloop/ui/screens/OnboardingScreen.kt
@@ -98,9 +98,7 @@ fun OnboardingScreen(
                     Button(onClick = {
                         if (currentStep == 0) {
                             // Save Name
-                            if (name.isNotEmpty()) {
-                                viewModel.saveName()
-                            }
+                            viewModel.saveName()
                         }
 
                         if (currentStep < totalSteps - 1) {


### PR DESCRIPTION
Moved the user name validation logic from OnboardingScreen (Composable) to OnboardingViewModel. Changed validation from isNotEmpty() to isNotBlank() to prevent saving whitespace-only names. This improves separation of concerns and testability.